### PR TITLE
Fix for too-generic egg-links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,16 @@ CHANGES
 
 - Fix in README for running sysegg standalone.
 
+- Distributions that aren't eggs but directories directly inside a
+  ``sys.path`` directory would have the actual system folder as their
+  location. This used to mean that everything in that system folder
+  can erroneously be used as a system egg. Not anymore, as those
+  directories are now symlinked directly instead of being used through
+  a too-generic ``.egg-link`` file.
+
+- This recipe uses symlinks for the above fix, which means it doesn't
+  work on windows anymore.
+
 
 0.1 (2013-02-05)
 ----------------

--- a/syseggrecipe/__init__.py
+++ b/syseggrecipe/__init__.py
@@ -1,0 +1,1 @@
+# Package

--- a/syseggrecipe/recipe.py
+++ b/syseggrecipe/recipe.py
@@ -39,14 +39,16 @@ class Recipe(object):
                     logger.info('Using %s for %s', dist.location, egg)
                 else:
                     # Ouch, a some_syspath_dir/EGGNAME dir...
-                    logger.debug("Sysegg's location is %s, which is too generic",
-                                 dist.location)
+                    logger.debug(
+                        "Sysegg %s's location is %s, which is too generic",
+                        egg, dist.location)
                     link_to_this = os.path.join(dist.location, dist.project_name)
                     if not os.path.exists(link_to_this):
                         raise RuntimeError(
                             "Trying {} for sysegg: not found".format(
                                 link_to_this))
-                    logger.info("Using %s for %s", link_to_this, egg)
+                    logger.info("Using direct path %s for %s", 
+                                link_to_this, egg)
                     link_file = os.path.join(dev_egg_dir, dist.project_name)
                     if os.path.exists(link_file):
                         os.remove(link_file)
@@ -62,6 +64,8 @@ class Recipe(object):
                                                     egginfo_filename)
                         link_file = os.path.join(dev_egg_dir, 
                                                  egginfo_filename)
+                        if os.path.exists(link_file):
+                            os.remove(link_file)
                         os.symlink(link_to_this, link_file)
                     # Older versions of ourselves used to create an
                     # egg-link file. Zap it if it is still there.

--- a/syseggrecipe/recipe.py
+++ b/syseggrecipe/recipe.py
@@ -1,4 +1,3 @@
-import glob
 import logging
 import os
 import pkg_resources
@@ -13,7 +12,7 @@ class Recipe(object):
         options.setdefault('eggs', '')
 
     def install(self):
-        log = logging.getLogger(self.name)
+        logger = logging.getLogger(self.name)
         eggs = self.options['eggs'].strip()
         eggs = [s.strip() for s in eggs.split('\n')]
 
@@ -23,7 +22,7 @@ class Recipe(object):
             try:
                 dist = pkg_resources.require(egg)[0]
             except pkg_resources.DistributionNotFound:
-                log.warn('No system distribution for %s found.' % egg)
+                logger.warn('No system distribution for %s found.' % egg)
                 if self.force_syseggs():
                     raise
 
@@ -37,17 +36,17 @@ class Recipe(object):
                     f = open(egg_egg_link, 'w')
                     f.write(dist.location)
                     f.close()
-                    log.info('Using %s for %s', dist.location, egg)
+                    logger.info('Using %s for %s', dist.location, egg)
                 else:
                     # Ouch, a some_syspath_dir/EGGNAME dir...
-                    log.debug("Sysegg's location is %s, which is too generic",
-                              dist.location)
+                    logger.debug("Sysegg's location is %s, which is too generic",
+                                 dist.location)
                     link_to_this = os.path.join(dist.location, egg)
                     if not os.path.exists(link_to_this):
                         raise RuntimeError(
                             "Trying {} for sysegg: not found".format(
                                 link_to_this))
-                    log.info("Using %s for %s", link_to_this, egg)
+                    logger.info("Using %s for %s", link_to_this, egg)
                     link_file = os.path.join(dev_egg_dir, egg)
                     if os.path.exists(link_file):
                         os.remove(link_file)

--- a/syseggrecipe/recipe.py
+++ b/syseggrecipe/recipe.py
@@ -41,13 +41,13 @@ class Recipe(object):
                     # Ouch, a some_syspath_dir/EGGNAME dir...
                     logger.debug("Sysegg's location is %s, which is too generic",
                                  dist.location)
-                    link_to_this = os.path.join(dist.location, egg)
+                    link_to_this = os.path.join(dist.location, dist.project_name)
                     if not os.path.exists(link_to_this):
                         raise RuntimeError(
                             "Trying {} for sysegg: not found".format(
                                 link_to_this))
                     logger.info("Using %s for %s", link_to_this, egg)
-                    link_file = os.path.join(dev_egg_dir, egg)
+                    link_file = os.path.join(dev_egg_dir, dist.project_name)
                     if os.path.exists(link_file):
                         os.remove(link_file)
                     os.symlink(link_to_this, link_file)
@@ -56,13 +56,21 @@ class Recipe(object):
                     egginfo_filenames = [
                         filename for filename in all_filenames
                         if filename.endswith('.egg-info')
-                        and filename.startswith(egg)]
+                        and filename.startswith(dist.project_name)]
                     for egginfo_filename in egginfo_filenames:
                         link_to_this = os.path.join(dist.location, 
                                                     egginfo_filename)
                         link_file = os.path.join(dev_egg_dir, 
                                                  egginfo_filename)
                         os.symlink(link_to_this, link_file)
+                    # Older versions of ourselves used to create an
+                    # egg-link file. Zap it if it is still there.
+                    erroneous_old_egglink = os.path.join(
+                        dev_egg_dir, '{}.egg-link'.format(dist.project_name))
+                    if os.path.exists(erroneous_old_egglink):
+                        os.remove(erroneous_old_egglink)
+                        logger.debug("Removed old egglink %S", 
+                                     erroneous_old_egglink)
 
         return ()
 

--- a/syseggrecipe/recipe.py
+++ b/syseggrecipe/recipe.py
@@ -1,9 +1,11 @@
-import os
+import glob
 import logging
+import os
 import pkg_resources
 
 
 class Recipe(object):
+
     def __init__(self, buildout, name, options):
         self.buildout = buildout
         self.name = name
@@ -26,13 +28,42 @@ class Recipe(object):
                     raise
 
             else:
-                egg_egg_link = os.path.join(
-                    dev_egg_dir,
-                    '%s.egg-link' % dist.project_name)
-                f = open(egg_egg_link, 'w')
-                f.write(dist.location)
-                f.close()
-                log.info('Using %s for %s' % (dist.location, egg))
+                if egg in dist.location:
+                    # Proper egg instead of a
+                    # /usr/lib/python/dist-packages dir.
+                    egg_egg_link = os.path.join(
+                        dev_egg_dir,
+                        '%s.egg-link' % dist.project_name)
+                    f = open(egg_egg_link, 'w')
+                    f.write(dist.location)
+                    f.close()
+                    log.info('Using %s for %s', dist.location, egg)
+                else:
+                    # Ouch, a some_syspath_dir/EGGNAME dir...
+                    log.debug("Sysegg's location is %s, which is too generic",
+                              dist.location)
+                    link_to_this = os.path.join(dist.location, egg)
+                    if not os.path.exists(link_to_this):
+                        raise RuntimeError(
+                            "Trying {} for sysegg: not found".format(
+                                link_to_this))
+                    log.info("Using %s for %s", link_to_this, egg)
+                    link_file = os.path.join(dev_egg_dir, egg)
+                    if os.path.exists(link_file):
+                        os.remove(link_file)
+                    os.symlink(link_to_this, link_file)
+                    # Also symlink the egg-info files.
+                    all_filenames = os.listdir(dist.location)
+                    egginfo_filenames = [
+                        filename for filename in all_filenames
+                        if filename.endswith('.egg-info')
+                        and filename.startswith(egg)]
+                    for egginfo_filename in egginfo_filenames:
+                        link_to_this = os.path.join(dist.location, 
+                                                    egginfo_filename)
+                        link_file = os.path.join(dev_egg_dir, 
+                                                 egginfo_filename)
+                        os.symlink(link_to_this, link_file)
 
         return ()
 


### PR DESCRIPTION
The too-generic `develop-eggs/*.egg-link` files that used to point at `/usr/lib/python/dist-packages` and so are now replaced by symlinks to their actual directories and a copy of their egg-info files. The latter are needed for the symlink to the directory to work.

See changelog entry.

It seems like it works wonderfully in a local test...
